### PR TITLE
Add support for additional params at create or update resources

### DIFF
--- a/src/OpenIDConnectUMAClient.php
+++ b/src/OpenIDConnectUMAClient.php
@@ -1755,17 +1755,13 @@ class OpenIDConnectUMAClient
 	 *
 	 * @throws OpenIDConnectClientException
 	 */
-	public function resource_set($name, $icon, $scopes, $type = null) {
+	public function resource_set($name, $icon, $scopes, array $extraParams = []) {
 		$resource_set_endpoint = $this->getProviderConfigValue('resource_registration_endpoint',true);
-		$send_object = (object)array(
+		$send_object = (object) array_merge($extraParams, array(
 			'name' => $name,
 			'icon_uri' => $icon,
 			'resource_scopes' => $scopes
-		);
-
-		if ($type !== null) {
-            $send_object->type = $type;
-        }
+		));
 
 		$headers = array("Authorization: Bearer {$this->accessToken}");
 		$response = $this->fetchURL($resource_set_endpoint, json_encode($send_object), $headers);
@@ -1812,17 +1808,13 @@ class OpenIDConnectUMAClient
 		return $return;
 	}
 
-	public function update_resource_set($id, $name, $icon, $scopes, $type = null) {
+	public function update_resource_set($id, $name, $icon, $scopes, array $extraParams = []) {
 		$resource_set_endpoint = $this->getProviderConfigValue('resource_registration_endpoint',true);
-		$send_object = (object)array(
+		$send_object = (object) array_merge($extraParams, array(
 			'name' => $name,
 			'icon_uri' => $icon,
 			'scopes' => $scopes
-		);
-
-        if ($type !== null) {
-            $send_object->type = $type;
-        }
+		));
 
 		$headers = array("Authorization: Bearer {$this->accessToken}");
 		$response = $this->fetchURL($resource_set_endpoint . '/' . $id, json_encode($send_object), $headers, 'PUT');


### PR DESCRIPTION
This PR reverts the chages of #4, intending to be more generic. I'm using Keycloak as a UMA provider, and it implements more additionals parameters to configure the resource, example, displayName and ownerManagedAccess.

Then, is more interesting expand the possibilities.